### PR TITLE
Changed http → https on the csg0.trade links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ I also suggest looking through the code to see how it works, and if you spot an 
 
 Live preview:
 
-* [http://csg0.trade](http://csg0.trade)
+* [https://csg0.trade](https://csg0.trade)
 
 # API Usage
 


### PR DESCRIPTION
Cause why wouldn't you want to access the secure version?