### PR TITLE
Check If a Items Price is NaN

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -36,10 +36,14 @@ Trade.prototype.getFloatValues = function getFloatValues() {
 Trade.prototype.getPrice = function getPrice(name, rateType, itemType) {
     const price = this.prices[name] * config.rates[rateType][itemType.name] || 0
     // Check if price is below ignoreItemsBelow value.
+	// Check if price is Not a Number and set it to Zero If this is True
     // If it is we set the value to 0
     if (price <= config.rates.ignoreItemsBelow) {
         return 0
     }
+	if (isNaN(this.prices[name])) {
+		return 0
+	}
     return price
 }
 


### PR DESCRIPTION
A Item currently gets a price of NaN if the Item is Trade-able but Not marketable (No Data For the price of this Item in the api because it can not be marketed on the Steam Community Market), In some games some of their items are trade-able but not marketable. This Sets the price of that Item to Zero