### PR TITLE
Fix Bot Not trading items less than ignore rate

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -43,6 +43,12 @@ Trade.prototype.getPrice = function getPrice(name, rateType, itemType) {
     return price
 }
 
+//Check the Bot Price So Your Bot Does Not Get Hit With Your Own Ingore Items Below
+Trade.prototype.getBotItemPrice = function getBotItemPrice(name, rateType, itemType) {
+    const price = this.prices[name] * config.rates[rateType][itemType.name] || 0
+    return price
+}
+
 Trade.prototype.getUserRates = function getUserRates() {
     return config.rates.user
 }
@@ -105,7 +111,7 @@ Trade.prototype.validateOffer = function validateOffer(object, callback) {
                     return async.forEach(Object.keys(botInventory), (index, cb) => {
                         const item = botInventory[index]
                         if (obj.bot.indexOf(item.assetid) !== -1) {
-                            const price = self.getPrice(item.data.market_hash_name, 'bot', item.item_type)
+                            const price = self.getBotItemPricePrice(item.data.market_hash_name, 'bot', item.item_type)
                             botCount += 1
                             if (config.rates.trashPriceBelow >= price) {
                                 botValue += price * config.rates.bot.trash


### PR DESCRIPTION
Currently if your bots inventory has a item that's price is less than the site's ignore rate, it will get its value set to zero just like it would for the user. This fix lets users trade for an item from the bot that is worth less than the ignore rate while still not  allowing the user to trade the site items that have a price less than your ignore rate.
For example:
The bot has a item worth .49 cents, your ignore rate is set to ignore all skins less than .50 cents. When a user would try to trade for the skin that is worth less than the ignore rate they would get the error "Could not get a price for item(s). Trade has been cancelled". This is because the bot was using the same getprice function as the user would and it would set the price too zero because it is less than the ignore rate.