### PR TITLE
Fixes Price Not Being Shown Correctly On Front End

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -106,7 +106,7 @@ $(function() {
                                 var item = bot.items[y];
                                 item.bot = i;
                                 if(app.priceList[item.data.market_hash_name] <= app.rates.trash) {
-                                    item.price = (app.priceList[item.data.market_hash_name] * app.rates.bot['trash']).toFixed(2);
+                                    item.price = (app.priceList[item.data.market_hash_name] * app.rates.bot[item.item_type.name] * app.rates.bot['trash']).toFixed(2);
                                 } else {
                                     item.price = (app.priceList[item.data.market_hash_name] * app.rates.bot[item.item_type.name]).toFixed(2);
                                 }
@@ -261,7 +261,7 @@ $(function() {
             for(var i in data.items) {
                 var item = data.items[i];
                 if(app.priceList[item.data.market_hash_name] <= app.rates.trash) {
-                    item.price = (app.priceList[item.data.market_hash_name] * app.rates.user['trash']).toFixed(2);
+                    item.price = (app.priceList[item.data.market_hash_name] * app.rates.user[item.item_type.name] * app.rates.user['trash']).toFixed(2);
                 } else {
                     item.price = (app.priceList[item.data.market_hash_name] * app.rates.user[item.item_type.name]).toFixed(2);
                 }
@@ -303,7 +303,7 @@ $(function() {
                 var item = bot.items[y];
                 item.bot = i;
                 if(app.priceList[item.data.market_hash_name] <= app.rates.trash) {
-                    item.price = (app.priceList[item.data.market_hash_name] * app.rates.bot['trash']).toFixed(2);
+                    item.price = (app.priceList[item.data.market_hash_name] * app.rates.bot[item.item_type.name] * app.rates.bot['trash']).toFixed(2);
                 } else {
                     item.price = (app.priceList[item.data.market_hash_name] * app.rates.bot[item.item_type.name]).toFixed(2);
                 }


### PR DESCRIPTION
When an item would be classified as trash it's price would be shown wrong on the front end. This is because it would ONLY multiply the items price by the trash rate. In the back end the trash multiplier is added on TOP of the item type rate. This would lead to the user getting a 'not enough value' error on the front end because the items price would be higher on the backend than it was shown to the user on the front end.